### PR TITLE
feat: add external storage permissions and legacy storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,11 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
+
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REQUEST_COMPANION_RUN_IN_BACKGROUND" />
     <uses-permission android:name="android.permission.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND" />
@@ -38,6 +40,7 @@
         android:icon="@drawable/ic_launcher_jdi"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
         android:theme="@style/Theme.SmallWebServer"
         android:usesCleartextTraffic="true"

--- a/app/src/main/java/com/martinporto/main/MainActivity.java
+++ b/app/src/main/java/com/martinporto/main/MainActivity.java
@@ -1,9 +1,16 @@
 package com.martinporto.main;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
+import android.provider.Settings;
 import android.text.Html;
 import android.view.Display;
 import android.view.Menu;
@@ -19,7 +26,9 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.Observer;
@@ -52,11 +61,14 @@ public class MainActivity extends AppCompatActivity implements Server.OnEventLis
 	Button btnSetup;
 	//JdiWebServer jdiWebServer;
 	WebView webview;
+
+	private static final int READ_WRITE_PERMISSION_REQUEST_CODE = 100;
 	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		
 		super.onCreate(savedInstanceState);
+		checkPermissions();
 		setContentView(R.layout.lab_activity);
 		context = this;
 		
@@ -147,6 +159,40 @@ public class MainActivity extends AppCompatActivity implements Server.OnEventLis
 			}
 		});
 		
+	}
+
+	private void checkPermissions() {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			int readPermission = checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
+			int writePermission = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+			if (readPermission != PackageManager.PERMISSION_GRANTED || writePermission != PackageManager.PERMISSION_GRANTED) {
+				requestPermissions(
+						new String[]{
+								Manifest.permission.READ_EXTERNAL_STORAGE,
+								Manifest.permission.WRITE_EXTERNAL_STORAGE
+						}, READ_WRITE_PERMISSION_REQUEST_CODE
+				);
+			}
+		}
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q && !Environment.isExternalStorageManager()) {
+			Intent intent = new Intent(
+					Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+					Uri.parse("package:" + getPackageName())
+			);
+			startActivity(intent);
+		}
+	}
+
+	@SuppressLint("MissingSuperCall")
+	@Override
+	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+		if (requestCode == READ_WRITE_PERMISSION_REQUEST_CODE) {
+			if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+				Toast.makeText(this, "Permission Granted", Toast.LENGTH_SHORT).show();
+			} else {
+				Toast.makeText(this, "Permission Denied", Toast.LENGTH_SHORT).show();
+			}
+		}
 	}
 	
 	public void webView() {


### PR DESCRIPTION
This commit introduces changes to handle external storage access in the app.

-   Added `WRITE_EXTERNAL_STORAGE` and `MANAGE_EXTERNAL_STORAGE` permissions with ScopedStorage ignore in `AndroidManifest.xml`.
-   Added `requestLegacyExternalStorage="true"` in application tag of `AndroidManifest.xml`.
- Implemented runtime permission requests for `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE`.
- Handle permission request results in `onRequestPermissionsResult`.
- For Android 11 (API level 30) and above, check for and request the `MANAGE_EXTERNAL_STORAGE` permission.